### PR TITLE
READMEにデプロイ手順のサンプルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,43 @@ Google Cloud Datastore ExportのデータをBigQueryにLoadするアプリケー
 
 ## Setup
 
-### BigQuery Loadをするための設定
+### Deploy
 
-#### Cloud StorageのRegistering object changesをPubSubに通知する設定
+#### 別ProjectのDatastoreをExportする時の設定
+
+example
+
+```
+# ds2bqをDeployするProjectで実行
+gcloud iam service-accounts create gcpug-ds2bq --display-name gcpug-ds2bq
+
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com --role=roles/datastore.importExportAdmin
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com --role=roles/storage.objectAdmin
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com --role=roles/bigquery.dataEditor
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com --role=roles/bigquery.jobUser
+
+gcloud beta run deploy gcpug-ds2bq --image=gcr.io/gcpug-container/ds2bq:v0.0.4 --service-account=gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com
+
+gcloud beta tasks queues create gcpug-ds2bq-datastore-job-check --max-concurrent-dispatches=1 --max-dispatches-per-second=1 --min-backoff=300s 
+
+gcloud beta run services update gcpug-ds2bq --set-env-vars=JOB_STATUS_CHECK_QUEUE_NAME=projects/gcpug-ds2bq-project/locations/asia-northeast1/queues/gcpug-ds2bq-datastore-job-check
+
+gcloud iam service-accounts create scheduler --display-name scheduler
+
+# exportするdatastoreのProjectで実行
+gcloud beta run services add-iam-policy-binding gcpug-ds2bq --region us-central1 --member serviceAccount:scheduler@gcpug-ds2bq-project.iam.gserviceaccount.com --role roles/run.invoker
+gcloud beta run services add-iam-policy-binding gcpug-ds2bq --region us-central1 --member serviceAccount:gcpug-ds2bq@$PROJECT_ID.iam.gserviceaccount.com --role roles/run.invoker 
+
+
+# ds2bqをDeployするProjectで実行
+gcloud scheduler jobs create http gcpug-ds2bq --schedule="2 2 * * *" --uri=https://gcpug-ds2bq-ed4d43qzla-uc.a.run.app/api/v1/datastore-export/ \
+  --message-body='{"projectID": "datastore-project","outputGCSFilePath": "gs://datastore-project-ds2bq-test","allKinds":true, "bqLoadProjectId":"datastore-project", "bqLoadDatasetId":"ds2bq_test"}' \
+  --oidc-service-account-email=scheduler@gcpug-ds2bq-project.iam.gserviceaccount.com
+```
+
+## BigQuery Loadをするための設定
+
+### Cloud StorageのRegistering object changesをPubSubに通知する設定
 
 ```
 # Objectの更新情報を通知するPubSub Topicを作成
@@ -15,15 +49,18 @@ gsutil notification create -t {TOPIC_NAME} -f json gs://{DATASTORE_EXPORT_BUCKET
 gcloud pubsub subscriptions create {SUBSCRIPTION_NAME} --topic {TOPIC_NAME}
 
 # Subscriberの名前を設定
-gcloud beta run services update ds2bq --update-env-vars STORAGE_CHANGE_NOTIFY_SUBSCRIPTION={SUBSCRIPTION_NAME}
+gcloud beta run services update gcpug-ds2bq --update-env-vars STORAGE_CHANGE_NOTIFY_SUBSCRIPTION={SUBSCRIPTION_NAME}
 ```
+
+#### 別ProjectのDatastoreをExportする時の設定
 
 example
 
 ```
 gsutil notification create -t gcpug-ds2bq-ds-export-object-change -f json gs://datastore-backup-gcpugjp-dev
 
-gcloud pubsub subscriptions create gcpug-ds2bq-ds-export-object-change --topic gcpug-ds2bq-ds-export-object-change
+# ds2bqをDeployするProjectで実行
+gcloud pubsub subscriptions create gcpug-ds2bq-ds-export-object-change --topic gcpug-ds2bq-ds-export-object-change --topic-project datastore-project
 
-gcloud beta run services update ds2bq --update-env-vars STORAGE_CHANGE_NOTIFY_SUBSCRIPTION=gcpug-ds2bq-ds-export-object-change
+gcloud beta run services update gcpug-ds2bq --update-env-vars STORAGE_CHANGE_NOTIFY_SUBSCRIPTION=gcpug-ds2bq-ds-export-object-change
 ```

--- a/bqload_service.go
+++ b/bqload_service.go
@@ -66,20 +66,20 @@ func (s *BQLoadService) ReceiveStorageChangeNotify(ctx context.Context, jobID st
 			}
 		}
 
-		_, err = bigquery.Load(ctx, lj.BQLoadProjectID, fmt.Sprintf("gs://%s/%s", gcsObject.Bucket, gcsObject.Name), lj.BQLoadDatasetID, kind)
+		bqLoadJobId, err := bigquery.Load(ctx, lj.BQLoadProjectID, fmt.Sprintf("gs://%s/%s", gcsObject.Bucket, gcsObject.Name), lj.BQLoadDatasetID, kind)
 		if err != nil {
 			log.Printf("failed bigquery.Load() message.ID=%v,GCSObjectID=%v,err=%v\n", message.ID, gcsObject.Name, err)
 			message.Nack()
 			return
 		}
+		fmt.Printf("bq insert job. ds2bqJobID=%v,kind=%v,gcs=%v,bqLoadJobID=%v\n", jobID, kind, gcsObject.Name, bqLoadJobId)
 
-		job, err := s.bqLoadJobStore.Update(ctx, jobID, kind, BQLoadJobStatusDone)
+		_, err = s.bqLoadJobStore.Update(ctx, jobID, kind, BQLoadJobStatusDone)
 		if err != nil {
 			log.Printf("failed BQLoadJobStore.Update() message.ID=%v,GCSObjectID=%v,err=%v\n", message.ID, gcsObject.Name, err)
 			message.Nack()
 			return
 		}
-		fmt.Printf("Update BQLoadJob kind=%v,status=%v\n", job.Kind, job.Status)
 
 		// TODO BQLoad Job Status Check QueueにAddする
 		message.Ack()


### PR DESCRIPTION
とりあえず、DatastoreのProjectとds2bqのProjectが別の場合のDeployの手順のサンプルをREADMEに追加した

close #16
