### PR TITLE
Datastore Export Jobの状態をDBに保存する

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,6 @@ gcloud beta emulators datastore start
 ```
 
 ```
-export GOOGLE_CLOUD_PROJECT="{YOUR_PROJECT_ID}"
+export GOOGLE_CLOUD_PROJECT=$DS2BQ_PROJECT_ID
+export JOB_STATUS_CHECK_QUEUE_NAME=projects/$DS2BQ_PROJECT_ID/locations/asia-northeast1/queues/gcpug-ds2bq-datastore-job-check
 ```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug
 gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$DS2BQ_PROJECT_ID.iam.gserviceaccount.com --role=roles/bigquery.dataEditor
 gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:gcpug-ds2bq@$DS2BQ_PROJECT_ID.iam.gserviceaccount.com --role=roles/bigquery.jobUser
 ```
+
+## Test
+
+```
+gcloud beta emulators datastore start
+```
+
+```
+export GOOGLE_CLOUD_PROJECT="{YOUR_PROJECT_ID}"
+```

--- a/bqload_job_store.go
+++ b/bqload_job_store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/morikuni/failure"
 	"go.mercari.io/datastore"
 )
@@ -45,6 +44,9 @@ type BQLoadJob struct {
 	UpdatedAt       time.Time
 	SchemaVersion   int
 }
+
+var _ datastore.PropertyLoadSaver = &BQLoadJob{}
+var _ datastore.KeyLoader = &BQLoadJob{}
 
 // BQLoadJobPutForm is Put する時のRequest内容
 type BQLoadJobPutForm struct {
@@ -88,12 +90,6 @@ func (e *BQLoadJob) Save(ctx context.Context) ([]datastore.Property, error) {
 	e.SchemaVersion = 1
 
 	return datastore.SaveStruct(ctx, e)
-}
-
-// NewJobID is JobIDを生成する
-// JobIDは一度のDatastore Export, BQ Loadで一つ発行され、複数KindのExportが全て終わっているかを確認するためのID
-func (store *BQLoadJobStore) NewJobID(ctx context.Context) string {
-	return uuid.New().String()
 }
 
 func (store *BQLoadJobStore) NewKey(ctx context.Context, jobID string, kind string) datastore.Key {

--- a/datastore_export_api.go
+++ b/datastore_export_api.go
@@ -84,18 +84,6 @@ func HandleDatastoreExportAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bqLoadKinds := BuildBQLoadKinds(ef, form.IgnoreBQLoadKinds)
-	jobStore, err := NewBQLoadJobStore(r.Context(), DatastoreClient)
-	if err != nil {
-		msg := fmt.Sprintf("failed NewBQLoadJobStore() form=%+v.err=%+v", form, err)
-		log.Println(msg)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, err := w.Write([]byte(msg))
-		if err != nil {
-			log.Println(err)
-		}
-		return
-	}
-
 	dsexportJobStore, err := NewDSExportJobStore(r.Context(), DatastoreClient)
 	if err != nil {
 		msg := fmt.Sprintf("failed NewDSExportJobStore() form=%+v.err=%+v", form, err)
@@ -108,10 +96,34 @@ func HandleDatastoreExportAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobID := dsexportJobStore.NewDS2BQJobID(r.Context())
-	_, err = jobStore.PutMulti(r.Context(), BuildBQLoadJobPutMultiForm(jobID, bqLoadKinds, form))
+	bqloadJobStore, err := NewBQLoadJobStore(r.Context(), DatastoreClient)
 	if err != nil {
-		msg := fmt.Sprintf("failed BQLoadJobStore.PutMulti() jobID=%v,bqLoadKinds=%+v.err=%+v", jobID, bqLoadKinds, err)
+		msg := fmt.Sprintf("failed NewBQLoadJobStore() form=%+v.err=%+v", form, err)
+		log.Println(msg)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	ds2bqJobID := dsexportJobStore.NewDS2BQJobID(r.Context())
+	_, err = dsexportJobStore.Create(r.Context(), ds2bqJobID, string(b))
+	if err != nil {
+		msg := fmt.Sprintf("failed DSExportJobStore.Create() ds2bqJobID=%v.err=%+v", ds2bqJobID, err)
+		log.Println(msg)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	_, err = bqloadJobStore.PutMulti(r.Context(), BuildBQLoadJobPutMultiForm(ds2bqJobID, bqLoadKinds, form))
+	if err != nil {
+		msg := fmt.Sprintf("failed BQLoadJobStore.PutMulti() ds2bqJobID=%v,bqLoadKinds=%+v.err=%+v", ds2bqJobID, bqLoadKinds, err)
 		log.Println(msg)
 		w.WriteHeader(http.StatusInternalServerError)
 		_, err := w.Write([]byte(msg))
@@ -136,14 +148,26 @@ func HandleDatastoreExportAPI(w http.ResponseWriter, r *http.Request) {
 	case http.StatusOK:
 		log.Printf("%+v", ope)
 
+		if _, err := dsexportJobStore.StartExportJob(r.Context(), ds2bqJobID, ope.Name); err != nil {
+			msg := fmt.Sprintf("failed DSExportJobStore.StartExportJob. ds2bqJobID=%v,jobName=%s.err=%+v", ds2bqJobID, ope.Name, err)
+			log.Println(msg)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte(msg))
+			if err != nil {
+				log.Println(err)
+			}
+			return
+		}
+
 		if err := queue.AddTask(r.Context(), &DatastoreExportJobCheckRequest{
-			DS2BQJobID:           jobID,
+			DS2BQJobID:           ds2bqJobID,
 			DatastoreExportJobID: ope.Name,
 		}); err != nil {
 			msg := fmt.Sprintf("failed queue.AddTask. jobName=%s.err=%+v", ope.Name, err)
 			log.Println(msg)
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, err := w.Write([]byte(msg))
 			if err != nil {
 				log.Println(err)
@@ -153,15 +177,27 @@ func HandleDatastoreExportAPI(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(ope.HTTPStatusCode)
 		res := DatastoreExportResponse{
-			DS2BQJobID:           jobID,
+			DS2BQJobID:           ds2bqJobID,
 			DatastoreExportJobID: ope.Name,
 		}
 		if err := json.NewEncoder(w).Encode(res); err != nil {
 			log.Printf("failed write response. %+v, err=%v", res, err)
 		}
 	default:
-		msg := fmt.Sprintf("datastore export API Response Code is not OK. form=%+v.ope=%+v", form, ope)
+		msg := fmt.Sprintf("failed DatastoreExportJob.INSERT(). form=%+v.ope.Error=%+v", form, ope.Error)
 		log.Println(msg)
+
+		if _, err := dsexportJobStore.FinishExportJob(r.Context(), ds2bqJobID, DSExportJobStatusFailed, fmt.Sprintf("failed DatastoreExportJob.INSERT(). Code=%v,Message=%v", ope.Error.Code, ope.Error.Message)); err != nil {
+			msg := fmt.Sprintf("failed DSExportJobStore.FinishExportJob. ds2bqJobID=%v.err=%+v", ds2bqJobID, err)
+			log.Println(msg)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte(msg))
+			if err != nil {
+				log.Println(err)
+			}
+			return
+		}
 		w.WriteHeader(ope.HTTPStatusCode)
 		_, err := w.Write([]byte(msg))
 		if err != nil {

--- a/datastore_export_api.go
+++ b/datastore_export_api.go
@@ -95,7 +95,20 @@ func HandleDatastoreExportAPI(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	jobID := jobStore.NewJobID(r.Context())
+
+	dsexportJobStore, err := NewDSExportJobStore(r.Context(), DatastoreClient)
+	if err != nil {
+		msg := fmt.Sprintf("failed NewDSExportJobStore() form=%+v.err=%+v", form, err)
+		log.Println(msg)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	jobID := dsexportJobStore.NewDS2BQJobID(r.Context())
 	_, err = jobStore.PutMulti(r.Context(), BuildBQLoadJobPutMultiForm(jobID, bqLoadKinds, form))
 	if err != nil {
 		msg := fmt.Sprintf("failed BQLoadJobStore.PutMulti() jobID=%v,bqLoadKinds=%+v.err=%+v", jobID, bqLoadKinds, err)

--- a/dsexport_job_store.go
+++ b/dsexport_job_store.go
@@ -1,0 +1,149 @@
+//go:generate qbg -usedatastorewrapper -output model_query.go .
+
+package main
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"time"
+
+	"github.com/morikuni/failure"
+	"go.mercari.io/datastore"
+)
+
+type DSExportJobStore struct {
+	ds datastore.Client
+}
+
+func NewDSExportJobStore(ctx context.Context, client datastore.Client) (*DSExportJobStore, error) {
+	return &DSExportJobStore{
+		ds: client,
+	}, nil
+}
+
+type DSExportJobStatus int
+
+const (
+	DSExportJobStatusDefault DSExportJobStatus = iota
+	DSExportJobStatusRunning
+	DSExportJobStatusFailed
+	DSExportJobStatusDone
+)
+
+type DSExportJob struct {
+	ID                      string `datastore:"-"`
+	DSExportJobID           string
+	JobRequestBody          string `datastore:",noindex"`
+	Status                  DSExportJobStatus
+	ChangeStatusAt          time.Time
+	DSExportResponseMessage string `datastore:",noindex"`
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	SchemaVersion           int
+}
+
+var _ datastore.PropertyLoadSaver = &DSExportJob{}
+var _ datastore.KeyLoader = &DSExportJob{}
+
+// LoadKey is Entity Load時にKeyを設定する
+func (e *DSExportJob) LoadKey(ctx context.Context, k datastore.Key) error {
+	e.ID = k.Name()
+
+	return nil
+}
+
+// Load is Entity Load時に呼ばれる
+func (e *DSExportJob) Load(ctx context.Context, ps []datastore.Property) error {
+	err := datastore.LoadStruct(ctx, e, ps)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Save is Entity Save時に呼ばれる
+func (e *DSExportJob) Save(ctx context.Context) ([]datastore.Property, error) {
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now()
+	}
+	e.UpdatedAt = time.Now()
+	e.SchemaVersion = 1
+
+	return datastore.SaveStruct(ctx, e)
+}
+
+// NewJobID is JobIDを生成する
+// JobIDは一度のDatastore Export, BQ Loadで一つ発行され、複数KindのExportが全て終わっているかを確認するためのID
+func (store *DSExportJobStore) NewDS2BQJobID(ctx context.Context) string {
+	return uuid.New().String()
+}
+
+func (store *DSExportJobStore) NewKey(ctx context.Context, ds2bqJobID string) datastore.Key {
+	return store.ds.NameKey("DSExportJob", ds2bqJobID, nil)
+}
+
+func (store *DSExportJobStore) Create(ctx context.Context, ds2bqJobID string, body string) (*DSExportJob, error) {
+	e := DSExportJob{
+		ID:             ds2bqJobID,
+		Status:         DSExportJobStatusDefault,
+		JobRequestBody: body,
+		ChangeStatusAt: time.Now(),
+	}
+	_, err := store.ds.Put(ctx, store.NewKey(ctx, ds2bqJobID), &e)
+	if err != nil {
+		return nil, failure.Wrap(err)
+	}
+	return &e, nil
+}
+
+func (store *DSExportJobStore) StartExportJob(ctx context.Context, ds2bqJobID string, dsExportJobID string) (*DSExportJob, error) {
+	key := store.NewKey(ctx, ds2bqJobID)
+	var e DSExportJob
+	_, err := store.ds.RunInTransaction(ctx, func(tx datastore.Transaction) error {
+		if err := tx.Get(key, &e); err != nil {
+			return err
+		}
+		e.DSExportJobID = dsExportJobID
+		e.Status = DSExportJobStatusRunning
+		e.ChangeStatusAt = time.Now()
+
+		_, err := tx.Put(key, &e)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, err
+		}
+		return nil, failure.Wrap(err, failure.Messagef("failed datastore.RunInTx() ds2bqJobID=%v", ds2bqJobID))
+	}
+	return &e, nil
+}
+
+func (store *DSExportJobStore) FinishExportJob(ctx context.Context, ds2bqJobID string, status DSExportJobStatus, message string) (*DSExportJob, error) {
+	key := store.NewKey(ctx, ds2bqJobID)
+	var e DSExportJob
+	_, err := store.ds.RunInTransaction(ctx, func(tx datastore.Transaction) error {
+		if err := tx.Get(key, &e); err != nil {
+			return err
+		}
+		e.Status = status
+		e.ChangeStatusAt = time.Now()
+		e.DSExportResponseMessage = message
+		_, err := tx.Put(key, &e)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, err
+		}
+		return nil, failure.Wrap(err, failure.Messagef("failed datastore.RunInTx() ds2bqJobID=%v", ds2bqJobID))
+	}
+	return &e, nil
+}

--- a/dsexport_job_store.go
+++ b/dsexport_job_store.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/morikuni/failure"
 	"go.mercari.io/datastore"
 )
@@ -93,6 +93,18 @@ func (store *DSExportJobStore) Create(ctx context.Context, ds2bqJobID string, bo
 	_, err := store.ds.Put(ctx, store.NewKey(ctx, ds2bqJobID), &e)
 	if err != nil {
 		return nil, failure.Wrap(err)
+	}
+	return &e, nil
+}
+
+func (store *DSExportJobStore) Get(ctx context.Context, ds2bqJobID string) (*DSExportJob, error) {
+	var e DSExportJob
+	err := store.ds.Get(ctx, store.NewKey(ctx, ds2bqJobID), &e)
+	if err != nil {
+		if err == datastore.ErrNoSuchEntity {
+			return nil, err
+		}
+		return nil, failure.Wrap(err, failure.Messagef("failed datastore.Get() ds2bqJobID=%v", ds2bqJobID))
 	}
 	return &e, nil
 }

--- a/dsexport_job_store_test.go
+++ b/dsexport_job_store_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cds "cloud.google.com/go/datastore"
+	"github.com/google/uuid"
+	"go.mercari.io/datastore/clouddatastore"
+)
+
+func TestDSExportJobStore_Lifecycle(t *testing.T) {
+	ctx := context.Background()
+
+	cdsc, err := cds.NewClient(ctx, uuid.New().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ds, err := clouddatastore.FromClient(ctx, cdsc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewDSExportJobStore(ctx, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := DatastoreExportRequest{
+		ProjectID:         "gcpugjp-dev",
+		OutputGCSFilePath: "gs://datastore-backup-gcpugjp-dev",
+		Kinds:             []string{"PugEvent"},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ds2bqJobID := s.NewDS2BQJobID(ctx)
+	{
+		job, err := s.Create(ctx, ds2bqJobID, string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e, g := DSExportJobStatusDefault, job.Status; e != g {
+			t.Fatalf("want Status is %v but got %v", e, g)
+		}
+		if e, g := string(body), job.JobRequestBody; e != g {
+			t.Fatalf("want JobRequestBody is %v but got %v", e, g)
+		}
+	}
+
+	{
+		const dsExportJobID = "dummyDatastoreExportJobID"
+		job, err := s.StartExportJob(ctx, ds2bqJobID, dsExportJobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e, g := DSExportJobStatusRunning, job.Status; e != g {
+			t.Fatalf("want Status is %v but got %v", e, g)
+		}
+		if e, g := dsExportJobID, job.DSExportJobID; e != g {
+			t.Fatalf("want DSExportJobID is %v but got %v", e, g)
+		}
+	}
+
+	{
+		const msg = "failed operation..."
+		job, err := s.FinishExportJob(ctx, ds2bqJobID, DSExportJobStatusFailed, msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e, g := DSExportJobStatusFailed, job.Status; e != g {
+			t.Fatalf("want Status is %v but got %v", e, g)
+		}
+		if e, g := msg, job.DSExportResponseMessage; e != g {
+			t.Fatalf("want Message is %v but got %v", e, g)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.12
 require (
 	cloud.google.com/go v0.43.0
 	github.com/google/uuid v1.1.1
+	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/morikuni/failure v0.11.0
 	github.com/sinmetal/gcpmetadata v0.0.0-20190722063420-84b06f752af2
 	go.mercari.io/datastore v1.5.0
 	google.golang.org/api v0.7.0
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610
+	google.golang.org/grpc v1.22.0
 )


### PR DESCRIPTION
Datastore Export Jobの状態を、状況に合わせてDBに保存することで、後から追いかけやすくした

close #30 